### PR TITLE
Load Aware Scheduling Changes

### DIFF
--- a/Data/WorkerInfoWrapper.py
+++ b/Data/WorkerInfoWrapper.py
@@ -11,3 +11,9 @@ class WorkerInfoWrapper:
 
     def __str__(self):
         return "[HostName: {} || PortNumber: {} || MaxThreadCount: {} || IsGPUEnabled: {} || Hardware Generation: {} || Current Available Capacity: {} || WorkerId: {}]".format(self.hostName, self.portNumber, self.maxThreadCount, self.isGPUEnabled, self.hardwareGeneration, self.currentAvailableCap, self.workerId)
+
+    def __lt__(self, other):
+        return self.portNumber < other.portNumber
+    
+    def __gt__(self, other):
+        return self.portNumber > other.portNumber


### PR DESCRIPTION
This change passes the correct current availability cap to repopulate/register calls.
It also updates the repopulate call we make from get_worker for GPU enabled tasks.